### PR TITLE
Fix truncation handling

### DIFF
--- a/script/main_openai.py
+++ b/script/main_openai.py
@@ -55,7 +55,8 @@ def send_discord_alert(message):
 message = generate_update()
 # Limit message length for Discord
 if len(message) > 2000:
-    message = message[:1990] + "\n...[truncated]"
+    slice_length = 2000 - len("\n...[truncated]")
+    message = message[:slice_length] + "\n...[truncated]"
 
 today = datetime.now().strftime("%Y-%m-%d")
 send_discord_alert(f"📅 {today} – Today's Tesla Update [OpenAI version]\n")


### PR DESCRIPTION
## Summary
- handle truncated Discord messages properly

## Testing
- `python -m py_compile script/main_openai.py`
- `python - <<'EOF'
message = 'a'*2020
if len(message) > 2000:
    slice_length = 2000 - len("\n...[truncated]")
    message = message[:slice_length] + "\n...[truncated]"
print(len(message))
print(message.endswith("...[truncated]"))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687d93b839e8832d9cf3e2e37ec9b800