### PR TITLE
Add real-time info fetch for Tesla updates

### DIFF
--- a/.github/workflows/ev_alert.yml
+++ b/.github/workflows/ev_alert.yml
@@ -20,12 +20,13 @@ jobs:
 
       - name: Install dependencies
         run:
-          pip install requests openai
+          pip install requests openai yfinance beautifulsoup4
 
       - name: Run the alert script
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          GNEWS_API_KEY: ${{ secrets.GNEWS_API_KEY }}
         run: python script/main_xai.py
 
   run-alert-openai:
@@ -42,11 +43,12 @@ jobs:
 
       - name: Install dependencies
         run:
-          pip install requests openai
+          pip install requests openai yfinance beautifulsoup4
 
       - name: Run the alert script
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GNEWS_API_KEY: ${{ secrets.GNEWS_API_KEY }}
         run: python script/main_openai.py
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # bot-alert-carindustry
-Fetches live data (e.g., Tesla Japan price or EV news)  and sends LINE Notify message
+Fetches live Tesla news and market data then posts a short summary to Discord.
+
+## Environment variables
+
+- `DISCORD_WEBHOOK` – target Discord webhook URL
+- `OPENAI_API_KEY` – API key for OpenAI (used by `main_openai.py`)
+- `XAI_API_KEY` – API key for xAI (used by `main_xai.py`)
+- `GNEWS_API_KEY` – API token for GNews used to fetch the latest Tesla articles
+
+## Dependencies
+
+The scripts require `openai`, `requests`, `yfinance` and `beautifulsoup4`.

--- a/script/data_sources.py
+++ b/script/data_sources.py
@@ -1,0 +1,49 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+import yfinance as yf
+
+
+def fetch_stock_summary():
+    ticker = yf.Ticker("TSLA")
+    data = ticker.history(period="1d")
+    if data.empty:
+        return "TSLA price unavailable"
+    price = data["Close"].iloc[-1]
+    open_price = data["Open"].iloc[-1]
+    change = price - open_price
+    pct = change / open_price * 100
+    return f"TSLA ${price:.2f} ({change:+.2f}, {pct:+.2f}%)"
+
+
+def fetch_latest_news(count=3):
+    api_key = os.getenv("GNEWS_API_KEY")
+    if not api_key:
+        return []
+    url = (
+        "https://gnews.io/api/v4/search?q=Tesla&lang=en&token="
+        f"{api_key}&max={count}"
+    )
+    res = requests.get(url, timeout=10)
+    res.raise_for_status()
+    data = res.json()
+    return [f"{a['title']} - {a['url']}" for a in data.get('articles', [])[:count]]
+
+
+def fetch_next_earnings():
+    res = requests.get("https://ir.tesla.com", timeout=10)
+    res.raise_for_status()
+    soup = BeautifulSoup(res.text, "html.parser")
+    event_view = soup.find("div", class_="view-company-events")
+    if not event_view:
+        return "N/A"
+    first = event_view.find("div", class_="views-row")
+    if not first:
+        return "N/A"
+    date_el = first.find(class_="date-display-single")
+    desc = first.get_text(" ", strip=True)
+    if date_el:
+        date_text = date_el.get_text(strip=True)
+        desc = desc.replace(date_text, "").strip()
+        return f"{date_text}: {desc}"
+    return desc

--- a/script/main_openai.py
+++ b/script/main_openai.py
@@ -2,6 +2,11 @@ import os
 import requests
 from openai import OpenAI
 from datetime import datetime
+from data_sources import (
+    fetch_latest_news,
+    fetch_next_earnings,
+    fetch_stock_summary,
+)
 
 # Load secrets from GitHub Actions
 webhook_url = os.getenv("DISCORD_WEBHOOK")
@@ -12,29 +17,30 @@ client = OpenAI(api_key=openai_api_key)
 
 # Generate GPT-powered message
 def generate_update():
+    news = fetch_latest_news()
+    stock = fetch_stock_summary()
+    earnings = fetch_next_earnings()
+
+    lines = []
+    if news:
+        lines.append("Recent News:")
+        lines.extend(f"- {n}" for n in news)
+    if stock:
+        lines.append(f"Stock: {stock}")
+    if earnings:
+        lines.append(f"Next earnings: {earnings}")
+
     prompt = (
-        "You are an expert automotive industry analyst. Generate a brief, concise and informative summary "
-        "about the very latest developments and daily trends in the automotive sector, especially related to Tesla. "
-        "Focus on:\n"
-        "- The most recent and notable daily news involving Tesla or the broader EV industry\n"
-        "- Tesla’s vehicle business\n"
-        "- Tesla’s non-automotive ventures such as Optimus (robotics), energy/solar business\n"
-        "- Any major updates about Elon Musk, and its impact to Tesla\n"
-        "- A quick note on Tesla’s current stock price trend and its reason, especially if it changed significantly\n"
-        "- If any, date the imminent major events that are related to EV industry and business like Tesla's Quarterly Earnings Call\n\n"
-        "If possible, include the source link next to the statement — but only if the link is known or provided. "
-        "Do not make up links. If no URL is given, just skip it. No need to say like source link not provided.\n\n"
-        "Assume this will be posted in a Discord server for car enthusiasts and developers in Japan. "
-        "Keep it under 5 sentences, and make it sound fresh and insightful. Include emojis where helpful. "
-        "If nothing major changed, still write a brief note saying so.\n"
-        "No need of any disclaimer or preamble, just the content.\n"
+        "Summarize the following Tesla-related information for a Discord post. "
+        "Limit the summary to about five sentences and include emojis if they help readability.\n\n"
+        + "\n".join(lines)
     )
 
     response = client.chat.completions.create(
         model="gpt-4",  # Or "gpt-3.5-turbo"
         messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt}
+            {"role": "system", "content": "You summarize given information."},
+            {"role": "user", "content": prompt},
         ],
         temperature=0.7
     )


### PR DESCRIPTION
## Summary
- gather Tesla news from GNews
- pull TSLA prices via yfinance
- scrape upcoming earnings info from Tesla IR site
- feed gathered info to OpenAI and xAI prompts and use summarization
- install new dependencies in the workflow
- document environment variables and dependencies
- rename `NEWS_API_KEY` to `GNEWS_API_KEY`

## Testing
- `python -m py_compile script/*.py`
- `python script/main_openai.py` *(fails: No module named 'requests')*
- `python script/main_xai.py` *(fails: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_687d95e9ffd0832d9cb205fdc99345f8